### PR TITLE
fix: update useRealtime return type to include connection status

### DIFF
--- a/src/client/use-realtime.ts
+++ b/src/client/use-realtime.ts
@@ -53,10 +53,10 @@ interface UseRealtimeOpts<T extends Record<string, any>, K extends EventPaths<T>
 
 export function useRealtime<T extends Record<string, any>>(
   opts?: { [K in EventPaths<T>]: UseRealtimeOpts<T, K> }[EventPaths<T>]
-): void
+): { status: ConnectionStatus }
 export function useRealtime<T extends Record<string, any>, const K extends EventPaths<T>>(
   opts?: UseRealtimeOpts<T, K>
-): void
+): { status: ConnectionStatus }
 
 // impl
 export function useRealtime<T extends Record<string, any>, const K extends EventPaths<T>>(


### PR DESCRIPTION
The `useRealtime` hook incorrectly sets `void` as the return type, when the implementation returns `{ status }`