### PR TITLE
fix: Include stream ID in historical events for schema validation

### DIFF
--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -105,10 +105,10 @@ class RealtimeBase<T extends Opts> {
       const messages = Object.entries(history)
 
       return messages
-        .map(([_, value]) => {
+        .map(([entryId, value]) => {
           if (typeof value === "object" && value !== null) {
-            const { id, channel, event, data } = value
-            return { data, event, id, channel }
+            const { channel, event, data } = value
+            return { data, event, id: entryId, channel }
           }
           return null
         })
@@ -151,7 +151,7 @@ class RealtimeBase<T extends Opts> {
             for (const [id, message] of entries) {
               if (!message.event || !events.includes(message.event)) continue
 
-              const result = userEvent.safeParse(message)
+              const result = userEvent.safeParse({ ...message, id })
               if (result.success) onData(result.data)
             }
 


### PR DESCRIPTION
## Fix history replay bug when subscribing with `history: true`

Fixes #15

### Summary
Resolves issue where late subscribers do not receive historical events when subscribing with `history: true`. The root cause was that stream entry IDs from XRANGE were not being included in the message objects before schema validation.

### Changes
- Fixed `history()` method to use XRANGE entry key as `id` field
- Fixed `subscribe()` method to merge stream ID into message before validation

See #15 for root cause analysis and reproduction steps.