### PR TITLE
fix(client): retain lastAck per channel while multiple subscriptions are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- **client:** Retain `lastAck` per channel while multiple `useRealtime` subscriptions are still active. Previously, `unregister` deleted ack state globally per channel, causing incorrect SSE replay when one hook unmounted while another still subscribed to the same channel.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The easiest way to add realtime features to any Next.js project.
 - 🔋 Built-in middleware and authentication helpers
 - 📶 100% HTTP-based: Redis streams & SSE
 
+### Multiple hooks on the same channel
+
+You can safely call `useRealtime()` multiple times with the same channel (for example, separate hooks that listen to different event subsets). The provider tracks per-channel ack state and only clears it when no active registration still uses that channel.
+
 ---
 
 ## Quickstart

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^19.1.9",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",
+    "vitest": "^3.2.4",
     "zod": "^4.1.11"
   },
   "peerDependencies": {
@@ -66,7 +67,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup",
-    "lint": "tsc"
+    "lint": "tsc",
+    "test": "vitest run"
   },
   "type": "module",
   "types": "dist/server/index.d.ts"

--- a/src/client/provider.tsx
+++ b/src/client/provider.tsx
@@ -13,6 +13,7 @@ import {
   type RealtimeMessage,
   EventPaths,
 } from "../shared/types.js"
+import { createSubscriptionRegistry } from "./subscription-registry.js"
 import { useRealtime, UseRealtimeOpts } from "./use-realtime.js"
 
 type RealtimeContextValue = {
@@ -38,25 +39,18 @@ export function RealtimeProvider({
 }: RealtimeProviderProps) {
   const [status, setStatus] = useState<ConnectionStatus>("disconnected")
 
-  const localSubsRef = useRef<
-    Map<string, { channels: Set<string>; cb: (msg: RealtimeMessage) => void }>
-  >(new Map())
+  const registryRef = useRef(createSubscriptionRegistry())
 
   const eventSourceRef = useRef<EventSource | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const pingTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttemptsRef = useRef(0)
-  const lastAckRef = useRef<Map<string, string>>(new Map())
   const lastReplaySinceRef = useRef<number | null>(null)
   const connectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const getAllNeededChannels = useCallback(() => {
-    const channels = new Set<string>()
-    localSubsRef.current.forEach((sub) => {
-      sub.channels.forEach((ch) => channels.add(ch))
-    })
-    return channels
+    return registryRef.current.getAllChannels()
   }, [])
 
   const cleanup = () => {
@@ -123,7 +117,7 @@ export function RealtimeProvider({
 
       const lastAckParam = channels
         .map((c) => {
-          const lastAck = lastAckRef.current.get(c) ?? String(replayEventsSince)
+          const lastAck = registryRef.current.lastAck.get(c) ?? String(replayEventsSince)
           return `last_ack_${encodeURIComponent(c)}=${encodeURIComponent(lastAck)}`
         })
         .join("&")
@@ -204,7 +198,7 @@ export function RealtimeProvider({
       const event = systemResult.data
       if (event.type === "connected") {
         if (event.cursor) {
-          lastAckRef.current.set(event.channel, event.cursor)
+          registryRef.current.lastAck.set(event.channel, event.cursor)
         }
       }
 
@@ -214,9 +208,9 @@ export function RealtimeProvider({
     const event = userEvent.safeParse(payload)
 
     if (event.success) {
-      lastAckRef.current.set(event.data.channel, event.data.id)
+      registryRef.current.lastAck.set(event.data.channel, event.data.id)
 
-      localSubsRef.current.forEach((sub) => {
+      registryRef.current.subscriptions.forEach((sub) => {
         if (sub.channels.has(event.data.channel)) {
           sub.cb(payload)
         }
@@ -233,20 +227,14 @@ export function RealtimeProvider({
     channels: string[],
     cb: (msg: RealtimeMessage) => void
   ) => {
-    localSubsRef.current.set(id, { channels: new Set(channels), cb })
+    registryRef.current.register(id, channels, cb)
     debouncedConnect()
   }
 
   const unregister = (id: string) => {
-    const channels = Array.from(localSubsRef.current.get(id)?.channels ?? [])
+    registryRef.current.unregister(id)
 
-    channels.forEach((channel) => {
-      lastAckRef.current.delete(channel)
-    })
-
-    localSubsRef.current.delete(id)
-
-    if (localSubsRef.current.size === 0) {
+    if (registryRef.current.subscriptions.size === 0) {
       cleanup()
 
       if (debounceTimeoutRef.current) {

--- a/src/client/subscription-registry.ts
+++ b/src/client/subscription-registry.ts
@@ -1,0 +1,54 @@
+import type { RealtimeMessage } from "../shared/types.js"
+import { getChannelsWithoutSubscribers } from "./subscription-utils.js"
+
+export type SubscriptionEntry = {
+  channels: Set<string>
+  cb: (msg: RealtimeMessage) => void
+}
+
+export type SubscriptionRegistry = {
+  subscriptions: Map<string, SubscriptionEntry>
+  lastAck: Map<string, string>
+  register: (id: string, channels: string[], cb: (msg: RealtimeMessage) => void) => void
+  unregister: (id: string) => void
+  getAllChannels: () => Set<string>
+}
+
+export function createSubscriptionRegistry(): SubscriptionRegistry {
+  const subscriptions = new Map<string, SubscriptionEntry>()
+  const lastAck = new Map<string, string>()
+
+  const register = (id: string, channels: string[], cb: (msg: RealtimeMessage) => void) => {
+    subscriptions.set(id, { channels: new Set(channels), cb })
+  }
+
+  const unregister = (id: string) => {
+    const channels = Array.from(subscriptions.get(id)?.channels ?? [])
+    subscriptions.delete(id)
+
+    const channelsToClearAck = getChannelsWithoutSubscribers(
+      channels,
+      subscriptions.values()
+    )
+
+    for (const channel of channelsToClearAck) {
+      lastAck.delete(channel)
+    }
+  }
+
+  const getAllChannels = () => {
+    const channels = new Set<string>()
+    subscriptions.forEach((subscription) => {
+      subscription.channels.forEach((channel) => channels.add(channel))
+    })
+    return channels
+  }
+
+  return {
+    subscriptions,
+    lastAck,
+    register,
+    unregister,
+    getAllChannels,
+  }
+}

--- a/src/client/subscription-utils.ts
+++ b/src/client/subscription-utils.ts
@@ -1,0 +1,18 @@
+export type ChannelSubscription = {
+  channels: Set<string>
+}
+
+export function getChannelsWithoutSubscribers(
+  removedChannels: Iterable<string>,
+  remainingSubscriptions: Iterable<ChannelSubscription>
+): string[] {
+  const activeChannels = new Set<string>()
+
+  for (const subscription of remainingSubscriptions) {
+    for (const channel of subscription.channels) {
+      activeChannels.add(channel)
+    }
+  }
+
+  return Array.from(removedChannels).filter((channel) => !activeChannels.has(channel))
+}

--- a/tests/subscription-registry.test.ts
+++ b/tests/subscription-registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createSubscriptionRegistry } from "../src/client/subscription-registry.js"
+import { getChannelsWithoutSubscribers } from "../src/client/subscription-utils.js"
+
+describe("getChannelsWithoutSubscribers", () => {
+  it("returns channels with no remaining subscribers", () => {
+    const remaining = [{ channels: new Set(["room-1", "room-2"]) }]
+
+    expect(getChannelsWithoutSubscribers(["room-1", "room-3"], remaining)).toEqual([
+      "room-3",
+    ])
+  })
+
+  it("returns all channels when none remain subscribed", () => {
+    expect(getChannelsWithoutSubscribers(["room-1"], [])).toEqual(["room-1"])
+  })
+})
+
+describe("createSubscriptionRegistry", () => {
+  it("retains lastAck while another registration still uses the channel", () => {
+    const registry = createSubscriptionRegistry()
+    const callbackA = vi.fn()
+    const callbackB = vi.fn()
+
+    registry.register("a", ["room-1"], callbackA)
+    registry.lastAck.set("room-1", "evt-1")
+
+    registry.register("b", ["room-1"], callbackB)
+    expect(registry.lastAck.get("room-1")).toBe("evt-1")
+
+    registry.unregister("a")
+    expect(registry.lastAck.get("room-1")).toBe("evt-1")
+    expect(registry.subscriptions.size).toBe(1)
+
+    registry.unregister("b")
+    expect(registry.lastAck.has("room-1")).toBe(false)
+    expect(registry.subscriptions.size).toBe(0)
+  })
+
+  it("clears lastAck only for channels with no remaining subscribers", () => {
+    const registry = createSubscriptionRegistry()
+
+    registry.register("a", ["room-1", "room-2"], vi.fn())
+    registry.lastAck.set("room-1", "evt-1")
+    registry.lastAck.set("room-2", "evt-2")
+
+    registry.register("b", ["room-1"], vi.fn())
+    registry.unregister("a")
+
+    expect(registry.lastAck.get("room-1")).toBe("evt-1")
+    expect(registry.lastAck.has("room-2")).toBe(false)
+  })
+
+  it("tracks the union of channels across registrations", () => {
+    const registry = createSubscriptionRegistry()
+
+    registry.register("a", ["room-1"], vi.fn())
+    registry.register("b", ["room-2"], vi.fn())
+
+    expect(Array.from(registry.getAllChannels()).sort()).toEqual(["room-1", "room-2"])
+
+    registry.unregister("a")
+    expect(Array.from(registry.getAllChannels())).toEqual(["room-2"])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+})


### PR DESCRIPTION
## Summary
Fixes incorrect event replay when multiple `useRealtime` hooks subscribe to the same channel. Previously, `unregister` deleted `lastAckRef` entries globally per channel, even when other active registrations still used that channel.

## Reproduction
1. Mount two `useRealtime({ channels: ["room"] })` hooks.
2. Receive an event; ack is stored for `"room"`.
3. Unmount one hook → `unregister` clears ack for `"room"`.
4. Second hook still mounted → reconnect sends stale/missing `last_ack` → server replays history.

## Fix
On `unregister`, remove `lastAck` only for channels that no longer have any active registration (derived from remaining subscriptions after the id is removed).

## Test plan
- [x] Unit tests for ack retention when one of two same-channel registrations unmounts
- [x] Unit tests for partial multi-channel cleanup
- [x] Manual: two hooks same channel, unmount one, confirm reconnect URL still includes correct `last_ack_<channel>`

## Out of scope
- Full SSE reconnect when adding a new channel to the union (separate issue)
- Client-side dedup by `(channel, event.id)` before fan-out
- `useRealtime({ history: true })` (see #20)