### PR TITLE
fix(server): clear ping interval on unsubscribe and scope it per subscription

### DIFF
--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -77,17 +77,6 @@ class RealtimeBase<T extends Opts> {
   private createEventHandlers(channel: string): any {
     const handlers: any = {}
     let unsubscribe: undefined | (() => void) = undefined
-    let pingInterval: undefined | NodeJS.Timeout = undefined
-
-    const startPingInterval = () => {
-      pingInterval = setInterval(() => {
-        this._redis?.publish(channel, { type: "ping", timestamp: Date.now() })
-      }, 60_000)
-    }
-
-    const stopPingInterval = () => {
-      if (pingInterval) clearInterval(pingInterval)
-    }
 
     handlers.history = async (args?: HistoryArgs) => {
       const redis = this._redis
@@ -136,6 +125,12 @@ class RealtimeBase<T extends Opts> {
 
       const sub = redis.subscribe<UserEvent>(channel)
 
+      let pingInterval: undefined | NodeJS.Timeout = undefined
+      const stopPingInterval = () => {
+        if (pingInterval) clearInterval(pingInterval)
+        pingInterval = undefined
+      }
+
       await new Promise<void>((resolve) => {
         sub.on("subscribe", async () => {
           if (history) {
@@ -168,7 +163,9 @@ class RealtimeBase<T extends Opts> {
 
           buffer.length = 0
           isHistoryReplayed = true
-          startPingInterval()
+          pingInterval = setInterval(() => {
+            this._redis?.publish(channel, { type: "ping", timestamp: Date.now() })
+          }, 60_000)
           resolve()
         })
       })
@@ -190,8 +187,12 @@ class RealtimeBase<T extends Opts> {
         stopPingInterval()
       })
 
-      unsubscribe = () => sub.unsubscribe()
-      return () => sub.unsubscribe()
+      const unsubscribeWithCleanup = () => {
+        stopPingInterval()
+        sub.unsubscribe()
+      }
+      unsubscribe = unsubscribeWithCleanup
+      return unsubscribeWithCleanup
     }
 
     const findSchema = (path: string[]): z.$ZodType | undefined => {


### PR DESCRIPTION
## Summary

Every server-side `realtime.channel(name).subscribe(...)` in a long-lived Node process leaks a permanent 60-second `setInterval` — even when the caller unsubscribes correctly. The interval is a GC root, so it pins its entire closure (the Redis client, the channel name, the user's `onData` callback, and everything that callback captures) for the life of the process, and it publishes a `{ type: "ping" }` message to the channel via the Upstash REST API every 60 seconds, forever.

This was found while debugging a production Node/Express memory leak in an app that subscribes once per chat message. It accumulated to ~1.9 GB of retained memory per day (reset only by redeploys), plus an ever-growing stream of pointless Upstash requests.

All changes are in one file: `src/server/realtime.ts` (`RealtimeBase.createEventHandlers`).

## Bug 1 (primary): a locally-called unsubscribe never clears the ping interval

The only `clearInterval` path was `sub.on("unsubscribe", ...)`. But that `Subscriber` event can **never** fire after a local `unsubscribe()`:

In `@upstash/redis` (verified against v1.36.3), the `Subscriber`'s `unsubscribe()` with no arguments synchronously **aborts the SSE fetch controller, clears its subscriptions map, and calls `removeAllListeners()`**. The `"unsubscribe"` event is only dispatched from `handleMessage` when an SSE frame of type `unsubscribe` arrives **over the wire** — but the connection was just aborted and the listeners removed, so it never arrives. Result: the interval started on the `"subscribe"` ack runs forever, no matter how correctly the caller behaves.

## Bug 2: concurrent subscribes to the same channel orphan each other's intervals

`channel(name)` caches one handlers object per channel name, so the closure variable `pingInterval` was shared by every `subscribe()` call for that channel. A second concurrent subscribe overwrote `pingInterval` without clearing the previous one, making the first interval permanently unclearable even via the wire-event path.

## Fix

- Move `pingInterval` and the stop helper **inside** `handlers.subscribe`, so each subscription owns its own interval.
- The function returned by `subscribe()` (and the value assigned to the shared `unsubscribe` variable) now clears the interval **before** calling `sub.unsubscribe()`. The stop helper is idempotent (resets the handle to `undefined`).
- The `sub.on("unsubscribe", ...)` wire-event path is kept and now references the per-subscription helper.

The shared `unsubscribe` variable is preserved unchanged — `handlers.unsubscribe()` depends on it.

## Impact (timer-count verification)

Counting live timer handles via `process.getActiveResourcesInfo().filter((r) => r === "Timeout").length`:

| step | active `Timeout` handles |
| --- | --- |
| baseline | 1 |
| 15 × `subscribe()` (unsubscribe never called) | 15 |
| 15 more × `subscribe()` (unsubscribe fn kept) | 30 |
| call all 15 kept unsubscribe fns | **30 → nothing reclaimed (before fix)** |

After the fix, the last step drops back to 15 (only the deliberately-abandoned subscriptions remain — abandoning a subscription without calling unsubscribe is the caller's bug).

## Verification

The repo has no test runner, so to keep the diff to one file with no new infrastructure I verified locally rather than committing a test (happy to add one in whatever framework maintainers prefer):

- `tsc` (lint) and `tsup` (build) both pass.
- A no-network test stubbing the Subscriber (`.on()` + `.unsubscribe()`, emitting `"subscribe"` asynchronously) confirms: one `subscribe()` starts exactly one interval and the returned fn clears it; two concurrent same-channel subscribes start two intervals and both clear (Bug 2 regression); the `"unsubscribe"` wire event still clears the interval (Bug 1's surviving path).

## Known limitations (out of scope)

Not addressed here: the `this.channels` cache grows unbounded when channel names contain unique ids, and `handlers.unsubscribe()` only targets the latest subscription on a channel. These are pre-existing and orthogonal to the leak.
