### PR TITLE
Prevent event loss during history replay

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "build": "tsup",
     "lint": "tsc",
-    "test": "bun run build && bun test test/*.test.js"
+    "test": "bun test"
   },
   "type": "module",
   "types": "dist/server/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   "license": "MIT",
   "scripts": {
     "build": "tsup",
-    "lint": "tsc"
+    "lint": "tsc",
+    "test": "bun run build && bun test test/*.test.js"
   },
   "type": "module",
   "types": "dist/server/index.d.ts"

--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -132,6 +132,7 @@ class RealtimeBase<T extends Opts> {
 
       const buffer: UserEvent[] = []
       let isHistoryReplayed = false
+      let isUnsubscribed = false
       let lastHistoryId: string | null = null
 
       const sub = redis.subscribe<UserEvent>(channel)
@@ -145,6 +146,14 @@ class RealtimeBase<T extends Opts> {
         const result = userEvent.safeParse(message)
         if (!result.success) return
 
+        // An event can arrive both via the XRANGE snapshot and pub/sub,
+        // since emit runs XADD before PUBLISH. Stream ids are monotonic,
+        // so anything at or before the last replayed id was already
+        // delivered from history. Events buffered while lastHistoryId is
+        // still null are deduplicated when the buffer is flushed below.
+        if (lastHistoryId && compareStreamIds(result.data.id, lastHistoryId) <= 0)
+          return
+
         if (!isHistoryReplayed) {
           buffer.push(result.data)
         } else {
@@ -153,6 +162,7 @@ class RealtimeBase<T extends Opts> {
       })
 
       sub.on("unsubscribe", () => {
+        isUnsubscribed = true
         stopPingInterval()
       })
 
@@ -188,7 +198,9 @@ class RealtimeBase<T extends Opts> {
 
           buffer.length = 0
           isHistoryReplayed = true
-          startPingInterval()
+          // An unsubscribe that fired during replay already ran
+          // stopPingInterval; starting the interval now would leak it.
+          if (!isUnsubscribed) startPingInterval()
           resolve()
         })
       })

--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -136,6 +136,21 @@ class RealtimeBase<T extends Opts> {
 
       const sub = redis.subscribe<UserEvent>(channel)
 
+      // Listen before replaying history so events that arrive after the XRANGE
+      // snapshot are buffered until the historical entries have been delivered.
+      sub.on("message", ({ message }) => {
+        if (!message.event || !events.includes(message.event)) return
+
+        const result = userEvent.safeParse(message)
+        if (!result.success) return
+
+        if (!isHistoryReplayed) {
+          buffer.push(result.data)
+        } else {
+          onData(result.data)
+        }
+      })
+
       await new Promise<void>((resolve) => {
         sub.on("subscribe", async () => {
           if (history) {
@@ -171,19 +186,6 @@ class RealtimeBase<T extends Opts> {
           startPingInterval()
           resolve()
         })
-      })
-
-      sub.on("message", ({ message }) => {
-        if (!message.event || !events.includes(message.event)) return
-
-        const result = userEvent.safeParse(message)
-        if (!result.success) return
-
-        if (!isHistoryReplayed) {
-          buffer.push(result.data)
-        } else {
-          onData(result.data)
-        }
       })
 
       sub.on("unsubscribe", () => {

--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -136,8 +136,9 @@ class RealtimeBase<T extends Opts> {
 
       const sub = redis.subscribe<UserEvent>(channel)
 
-      // Listen before replaying history so events that arrive after the XRANGE
-      // snapshot are buffered until the historical entries have been delivered.
+      // Register listeners before replaying history so events that arrive
+      // after the XRANGE snapshot are buffered until the historical entries
+      // have been delivered, and an unsubscribe during replay is not missed.
       sub.on("message", ({ message }) => {
         if (!message.event || !events.includes(message.event)) return
 
@@ -149,6 +150,10 @@ class RealtimeBase<T extends Opts> {
         } else {
           onData(result.data)
         }
+      })
+
+      sub.on("unsubscribe", () => {
+        stopPingInterval()
       })
 
       await new Promise<void>((resolve) => {
@@ -186,10 +191,6 @@ class RealtimeBase<T extends Opts> {
           startPingInterval()
           resolve()
         })
-      })
-
-      sub.on("unsubscribe", () => {
-        stopPingInterval()
       })
 
       unsubscribe = () => sub.unsubscribe()

--- a/test/realtime.test.js
+++ b/test/realtime.test.js
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test"
+
+import { Realtime } from "../dist/server/index.js"
+
+class FakeSubscriber {
+  listeners = new Map()
+
+  on(event, listener) {
+    const listeners = this.listeners.get(event) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(event, listeners)
+  }
+
+  emit(event, payload) {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload)
+    }
+  }
+
+  async unsubscribe() {
+    this.emit("unsubscribe", 0)
+  }
+}
+
+function deferred() {
+  let resolve
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function historyEntry({ id: _id, ...event }) {
+  return event
+}
+
+async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
+  const subscriber = new FakeSubscriber()
+  const snapshotCaptured = deferred()
+  const releaseHistory = deferred()
+  const stream = new Map(historyEvents.map((event) => [event.id, historyEntry(event)]))
+  const redis = {
+    subscribe() {
+      return subscriber
+    },
+    async xrange() {
+      const snapshot = Object.fromEntries(stream)
+      snapshotCaptured.resolve()
+      await releaseHistory.promise
+      return snapshot
+    },
+    async publish() {
+      return 1
+    },
+  }
+  const received = []
+  const realtime = new Realtime({ redis })
+  const subscribe = realtime.channel("updates").subscribe({
+    events: ["update"],
+    history: true,
+    onData(event) {
+      received.push(event)
+    },
+  })
+
+  subscriber.emit("subscribe", 1)
+  await snapshotCaptured.promise
+
+  stream.set(liveEvent.id, historyEntry(liveEvent))
+  subscriber.emit("message", { channel: "updates", message: liveEvent })
+
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+
+  return { received, unsubscribe }
+}
+
+test("replays history before live events received during replay", async () => {
+  const historyEvent = {
+    id: "1-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "history" },
+  }
+  const liveEvent = {
+    id: "2-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "live" },
+  }
+  const { received, unsubscribe } = await subscribeWithDelayedHistory({
+    historyEvents: [historyEvent],
+    liveEvent,
+  })
+
+  try {
+    expect(received).toEqual([historyEvent, liveEvent])
+  } finally {
+    await unsubscribe()
+  }
+})
+
+test("deduplicates live events already included in history", async () => {
+  const event = {
+    id: "2-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "overlap" },
+  }
+  const { received, unsubscribe } = await subscribeWithDelayedHistory({
+    historyEvents: [event],
+    liveEvent: event,
+  })
+
+  try {
+    expect(received).toEqual([event])
+  } finally {
+    await unsubscribe()
+  }
+})

--- a/test/realtime.test.js
+++ b/test/realtime.test.js
@@ -9,7 +9,7 @@ class FakeSubscriber extends EventEmitter {
   }
 }
 
-async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
+function setup({ historyEvents }) {
   const subscriber = new FakeSubscriber()
   const snapshotCaptured = Promise.withResolvers()
   const releaseHistory = Promise.withResolvers()
@@ -38,6 +38,13 @@ async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
       received.push(event)
     },
   })
+
+  return { subscriber, snapshotCaptured, releaseHistory, subscribe, received }
+}
+
+async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
+  const { subscriber, snapshotCaptured, releaseHistory, subscribe, received } =
+    setup({ historyEvents })
 
   subscriber.emit("subscribe", 1)
   await snapshotCaptured.promise
@@ -85,4 +92,63 @@ test("deduplicates live events already included in history", async () => {
   })
 
   expect(received).toEqual([event])
+})
+
+test("deduplicates live events that arrive after replay completes", async () => {
+  const historyEvent = {
+    id: "2-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "overlap" },
+  }
+  const freshEvent = {
+    id: "3-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "fresh" },
+  }
+  const { subscriber, releaseHistory, subscribe, received } = setup({
+    historyEvents: [historyEvent],
+  })
+
+  subscriber.emit("subscribe", 1)
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+
+  // emit runs XADD before PUBLISH, so the pub/sub copy of an event already
+  // captured by the XRANGE snapshot can arrive after replay has finished.
+  subscriber.emit("message", { channel: "updates", message: historyEvent })
+  subscriber.emit("message", { channel: "updates", message: freshEvent })
+  unsubscribe()
+
+  expect(received).toEqual([historyEvent, freshEvent])
+})
+
+test("does not start the ping interval when unsubscribed during replay", async () => {
+  const intervals = []
+  const originalSetInterval = globalThis.setInterval
+  globalThis.setInterval = (handler, timeout, ...args) => {
+    const handle = originalSetInterval(handler, timeout, ...args)
+    intervals.push(handle)
+    return handle
+  }
+
+  try {
+    const { subscriber, snapshotCaptured, releaseHistory, subscribe } = setup({
+      historyEvents: [],
+    })
+
+    subscriber.emit("subscribe", 1)
+    await snapshotCaptured.promise
+
+    await subscriber.unsubscribe()
+
+    releaseHistory.resolve()
+    await subscribe
+
+    expect(intervals).toHaveLength(0)
+  } finally {
+    globalThis.setInterval = originalSetInterval
+    for (const handle of intervals) clearInterval(handle)
+  }
 })

--- a/test/realtime.test.js
+++ b/test/realtime.test.js
@@ -1,53 +1,29 @@
 import { expect, test } from "bun:test"
+import { EventEmitter } from "node:events"
 
-import { Realtime } from "../dist/server/index.js"
+import { Realtime } from "../src/server/index.js"
 
-class FakeSubscriber {
-  listeners = new Map()
-
-  on(event, listener) {
-    const listeners = this.listeners.get(event) ?? new Set()
-    listeners.add(listener)
-    this.listeners.set(event, listeners)
-  }
-
-  emit(event, payload) {
-    for (const listener of this.listeners.get(event) ?? []) {
-      listener(payload)
-    }
-  }
-
+class FakeSubscriber extends EventEmitter {
   async unsubscribe() {
     this.emit("unsubscribe", 0)
   }
 }
 
-function deferred() {
-  let resolve
-  const promise = new Promise((resolvePromise) => {
-    resolve = resolvePromise
-  })
-  return { promise, resolve }
-}
-
-function historyEntry({ id: _id, ...event }) {
-  return event
-}
-
 async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
   const subscriber = new FakeSubscriber()
-  const snapshotCaptured = deferred()
-  const releaseHistory = deferred()
-  const stream = new Map(historyEvents.map((event) => [event.id, historyEntry(event)]))
+  const snapshotCaptured = Promise.withResolvers()
+  const releaseHistory = Promise.withResolvers()
+  const history = Object.fromEntries(
+    historyEvents.map(({ id, ...fields }) => [id, fields])
+  )
   const redis = {
     subscribe() {
       return subscriber
     },
     async xrange() {
-      const snapshot = Object.fromEntries(stream)
       snapshotCaptured.resolve()
       await releaseHistory.promise
-      return snapshot
+      return history
     },
     async publish() {
       return 1
@@ -66,13 +42,13 @@ async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
   subscriber.emit("subscribe", 1)
   await snapshotCaptured.promise
 
-  stream.set(liveEvent.id, historyEntry(liveEvent))
   subscriber.emit("message", { channel: "updates", message: liveEvent })
 
   releaseHistory.resolve()
   const unsubscribe = await subscribe
+  unsubscribe()
 
-  return { received, unsubscribe }
+  return received
 }
 
 test("replays history before live events received during replay", async () => {
@@ -88,16 +64,12 @@ test("replays history before live events received during replay", async () => {
     channel: "updates",
     data: { value: "live" },
   }
-  const { received, unsubscribe } = await subscribeWithDelayedHistory({
+  const received = await subscribeWithDelayedHistory({
     historyEvents: [historyEvent],
     liveEvent,
   })
 
-  try {
-    expect(received).toEqual([historyEvent, liveEvent])
-  } finally {
-    await unsubscribe()
-  }
+  expect(received).toEqual([historyEvent, liveEvent])
 })
 
 test("deduplicates live events already included in history", async () => {
@@ -107,14 +79,10 @@ test("deduplicates live events already included in history", async () => {
     channel: "updates",
     data: { value: "overlap" },
   }
-  const { received, unsubscribe } = await subscribeWithDelayedHistory({
+  const received = await subscribeWithDelayedHistory({
     historyEvents: [event],
     liveEvent: event,
   })
 
-  try {
-    expect(received).toEqual([event])
-  } finally {
-    await unsubscribe()
-  }
+  expect(received).toEqual([event])
 })


### PR DESCRIPTION
## Summary

Fixes #23 

`subscribe()` registered its `message` listener only after the subscribe + history-replay promise resolved, so any event published while the `XRANGE` replay was in flight was silently dropped. The buffering mechanism (`buffer` / `isHistoryReplayed`) existed for exactly this window but was unreachable under that ordering.

This PR registers all listeners before awaiting the subscription:

- Live events arriving during replay are buffered and delivered after the historical entries, deduplicated against the last replayed stream id (an event can appear both in the `XRANGE` snapshot and via pub/sub, since `emit` runs `XADD` before `PUBLISH`).
- The `unsubscribe` listener is also registered up front, matching the listener-registration pattern in `handler.ts`, so an unsubscribe during replay is not missed.

## Tests

Adds a `bun test` suite (run with `bun run test`) using a fake subscriber and redis whose `xrange` is gated on a promise, reproducing the race deterministically:

- replays history before live events received during replay
- deduplicates live events already included in history