### PR TITLE
Expose cursor-based resumption for server-side subscriptions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@upstash/realtime",
@@ -17,6 +18,10 @@
         "react-dom": ">=16.8.0",
         "zod": "^3.25.0 || ^4.0.0",
       },
+      "optionalPeers": [
+        "react",
+        "react-dom",
+      ],
     },
   },
   "packages": {
@@ -240,17 +245,11 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "react": ["react@19.1.1", "", {}, "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ=="],
-
-    "react-dom": ["react-dom@19.1.1", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.1" } }, "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw=="],
-
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "rollup": ["rollup@4.52.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.3", "@rollup/rollup-android-arm64": "4.52.3", "@rollup/rollup-darwin-arm64": "4.52.3", "@rollup/rollup-darwin-x64": "4.52.3", "@rollup/rollup-freebsd-arm64": "4.52.3", "@rollup/rollup-freebsd-x64": "4.52.3", "@rollup/rollup-linux-arm-gnueabihf": "4.52.3", "@rollup/rollup-linux-arm-musleabihf": "4.52.3", "@rollup/rollup-linux-arm64-gnu": "4.52.3", "@rollup/rollup-linux-arm64-musl": "4.52.3", "@rollup/rollup-linux-loong64-gnu": "4.52.3", "@rollup/rollup-linux-ppc64-gnu": "4.52.3", "@rollup/rollup-linux-riscv64-gnu": "4.52.3", "@rollup/rollup-linux-riscv64-musl": "4.52.3", "@rollup/rollup-linux-s390x-gnu": "4.52.3", "@rollup/rollup-linux-x64-gnu": "4.52.3", "@rollup/rollup-linux-x64-musl": "4.52.3", "@rollup/rollup-openharmony-arm64": "4.52.3", "@rollup/rollup-win32-arm64-msvc": "4.52.3", "@rollup/rollup-win32-ia32-msvc": "4.52.3", "@rollup/rollup-win32-x64-gnu": "4.52.3", "@rollup/rollup-win32-x64-msvc": "4.52.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A=="],
-
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/docs/server-side-cursor-resumption.md
+++ b/docs/server-side-cursor-resumption.md
@@ -1,0 +1,34 @@
+# Server-side cursor resumption
+
+Each event delivered by a server-side subscription includes an opaque, channel-specific
+`cursor`. Pass the last successfully handled cursor as `after` to replay only later events before
+continuing with live delivery:
+
+```ts
+import { CursorUnavailableError, isRealtimeCursor } from "@upstash/realtime"
+
+const stored = await loadCursor("jobs")
+
+if (stored !== null && isRealtimeCursor(stored)) {
+  try {
+    const unsubscribe = await realtime.channel("jobs").subscribe({
+      events: ["job.updated"],
+      after: stored,
+      onData(message) {
+        handleJobUpdate(message.data)
+        saveCursor("jobs", message.cursor)
+      },
+    })
+  } catch (error) {
+    if (error instanceof CursorUnavailableError) {
+      // Reload canonical state before starting a new subscription.
+    }
+  }
+}
+```
+
+`after` is exclusive and cannot be combined with `history`. `RealtimeCursor` is a branded
+string: `message.cursor` persists as a plain string, and a value read back from storage is
+narrowed with `isRealtimeCursor` before it can be passed to `after`. Cursors must be reused
+without modification on the channel that issued them. A cursor that has been trimmed, expired or
+is otherwise unavailable rejects the initial subscription with `CursorUnavailableError`.

--- a/src/client/use-realtime.ts
+++ b/src/client/use-realtime.ts
@@ -36,7 +36,7 @@ export function useRealtime<T extends Record<string, any>, const E extends Event
       return
     }
 
-    const validChannels = channels.filter(Boolean) as string[]
+    const validChannels = channels.filter((channel): channel is string => !!channel)
     if (validChannels.length === 0) return
 
     context.register(registrationId, validChannels, (msg) => {
@@ -45,7 +45,7 @@ export function useRealtime<T extends Record<string, any>, const E extends Event
       if (result.success) {
         const { event, channel, data } = result.data
 
-        if (events && events.length > 0 && !events.includes(event as E)) {
+        if (events && events.length > 0 && !events.some((name) => name === event)) {
           return
         }
 

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -249,7 +249,7 @@ export function json(data: SystemEvent | UserEvent) {
 
 export class StreamingResponse extends Response {
   constructor(res: ReadableStream<any>, init?: ResponseInit) {
-    super(res as any, {
+    super(res, {
       ...init,
       status: 200,
       headers: {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,2 +1,3 @@
 export * from "./handler.js"
 export * from "./realtime.js"
+export { type RealtimeCursor } from "../shared/types.js"

--- a/src/server/realtime.ts
+++ b/src/server/realtime.ts
@@ -4,6 +4,8 @@ import {
   EventPaths,
   EventPayloadUnion,
   HistoryArgs,
+  realtimeCursor,
+  type RealtimeCursor,
   userEvent,
   type UserEvent
 } from "../shared/types.js"
@@ -12,6 +14,23 @@ import { compareStreamIds } from "./utils.js"
 const DEFAULT_VERCEL_FLUID_TIMEOUT = 300
 
 type Schema = Record<string, z.$ZodType | Record<string, any>>
+
+/** Narrows a stored string back to a cursor that can be passed as `after`. */
+export function isRealtimeCursor(value: string): value is RealtimeCursor {
+  return realtimeCursor.safeParse(value).success
+}
+
+export class CursorUnavailableError extends Error {
+  readonly channel: string
+  readonly cursor: string
+
+  constructor(channel: string, cursor: string) {
+    super(`Cursor ${cursor} is unavailable for channel ${channel}.`)
+    this.name = "CursorUnavailableError"
+    this.channel = channel
+    this.cursor = cursor
+  }
+}
 
 export type Opts = {
   schema?: Schema
@@ -97,10 +116,7 @@ class RealtimeBase<T extends Opts> {
       const end = args?.end ? String(args.end) : "+"
       const limit = Math.min(args?.limit ?? 1000, 1000)
 
-      const history = (await redis.xrange(channel, start, end, limit)) as Record<
-        string,
-        UserEvent
-      >
+      const history = await redis.xrange(channel, start, end, limit)
 
       const messages = Object.entries(history)
 
@@ -126,14 +142,26 @@ class RealtimeBase<T extends Opts> {
       events,
       onData,
       history,
+      after,
     }: SubscribeArgs<any, any>): Promise<() => void> => {
+      if (after !== undefined && history !== undefined) {
+        throw new TypeError("The after and history options cannot be used together.")
+      }
+      if (after !== undefined && !isRealtimeCursor(after)) {
+        throw new CursorUnavailableError(channel, after)
+      }
+
       const redis = this._redis
       if (!redis) throw new Error("Redis not configured.")
 
       const buffer: UserEvent[] = []
       let isHistoryReplayed = false
       let isUnsubscribed = false
-      let lastHistoryId: string | null = null
+      let lastHistoryId: string | null = after ?? null
+
+      const deliver = (message: UserEvent) => {
+        onData({ ...message, cursor: message.id })
+      }
 
       const sub = redis.subscribe<UserEvent>(channel)
 
@@ -157,7 +185,7 @@ class RealtimeBase<T extends Opts> {
         if (!isHistoryReplayed) {
           buffer.push(result.data)
         } else {
-          onData(result.data)
+          deliver(result.data)
         }
       })
 
@@ -166,42 +194,63 @@ class RealtimeBase<T extends Opts> {
         stopPingInterval()
       })
 
-      await new Promise<void>((resolve) => {
+      await new Promise<void>((resolve, reject) => {
         sub.on("subscribe", async () => {
-          if (history) {
-            const start =
-              typeof history === "object" && history.start ? String(history.start) : "-"
-            const end =
-              typeof history === "object" && history.end ? String(history.end) : "+"
-            const limit = typeof history === "object" ? history.limit : undefined
+          try {
+            let entries: [string, Record<string, unknown>][] = []
 
-            const messages = await redis.xrange(channel, start, end, limit)
+            if (after !== undefined) {
+              const messages = await redis.xrange(channel, after, "+")
+              entries = Object.entries(messages)
 
-            const entries = Object.entries(messages)
+              if (entries[0]?.[0] !== after) {
+                throw new CursorUnavailableError(channel, after)
+              }
+              // Drop the cursor entry itself: after is exclusive.
+              entries = entries.slice(1)
+            } else if (history) {
+              const start =
+                typeof history === "object" && history.start ? String(history.start) : "-"
+              const end =
+                typeof history === "object" && history.end ? String(history.end) : "+"
+              const limit = typeof history === "object" ? history.limit : undefined
+              const messages = await redis.xrange(channel, start, end, limit)
+
+              entries = Object.entries(messages)
+            }
+
             for (const [id, message] of entries) {
               if (!message.event || !events.includes(message.event)) continue
 
               const result = userEvent.safeParse({ ...message, id })
-              if (result.success) onData(result.data)
+              if (result.success) deliver(result.data)
             }
 
-            if (entries.length > 0) {
-              lastHistoryId = entries[entries.length - 1]?.[0] ?? null
+            const lastEntry = entries[entries.length - 1]
+            if (lastEntry) lastHistoryId = lastEntry[0]
+
+            for (const message of buffer) {
+              if (lastHistoryId && compareStreamIds(message.id, lastHistoryId) <= 0)
+                continue
+              deliver(message)
             }
-          }
 
-          for (const message of buffer) {
-            if (lastHistoryId && compareStreamIds(message.id, lastHistoryId) <= 0)
-              continue
-            onData(message)
+            buffer.length = 0
+            isHistoryReplayed = true
+            // An unsubscribe that fired during replay already ran
+            // stopPingInterval; starting the interval now would leak it.
+            if (!isUnsubscribed) startPingInterval()
+            resolve()
+          } catch (error) {
+            if (!isUnsubscribed) {
+              try {
+                await sub.unsubscribe()
+              } catch (unsubscribeError) {
+                this._logger.error("⚠️ Error closing subscription:", unsubscribeError)
+              }
+            }
+            reject(error)
           }
-
-          buffer.length = 0
-          isHistoryReplayed = true
-          // An unsubscribe that fired during replay already ran
-          // stopPingInterval; starting the interval now would leak it.
-          if (!isUnsubscribed) startPingInterval()
-          resolve()
         })
       })
 
@@ -233,13 +282,15 @@ class RealtimeBase<T extends Opts> {
         return
       }
 
-      const id = await this._redis.xadd(
-        channel,
-        "*",
-        { data, event, channel } as Record<string, unknown>,
-        {
-          ...(this._trimConfig && { trim: this._trimConfig }),
-        }
+      const id = realtimeCursor.parse(
+        await this._redis.xadd(
+          channel,
+          "*",
+          { data, event, channel },
+          {
+            ...(this._trimConfig && { trim: this._trimConfig }),
+          }
+        )
       )
 
       const payload: UserEvent = {
@@ -316,11 +367,18 @@ export type HistoryMessage = {
   data: unknown
 }
 
+export type SubscriptionEvent<
+  T extends Opts,
+  E extends EventPaths<T["schema"]>
+> = EventPayloadUnion<T["schema"], E> & { cursor: RealtimeCursor }
+
 type SubscribeArgs<T extends Opts, E extends EventPaths<T["schema"]>> = {
   events: readonly E[]
-  onData: (arg: EventPayloadUnion<T["schema"], E>) => void
-  history?: boolean | HistoryArgs
-}
+  onData: (arg: SubscriptionEvent<T, E>) => void
+} & (
+  | { history?: boolean | HistoryArgs; after?: never }
+  | { after: RealtimeCursor; history?: never }
+)
 
 type RealtimeChannel<T extends Opts> = {
   subscribe: <E extends EventPaths<T["schema"]>>(

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,7 +1,10 @@
 export function compareStreamIds(a: string, b: string): number {
-    const [aTime = 0, aSeq = 0] = a.split("-").map(Number)
-    const [bTime = 0, bSeq = 0] = b.split("-").map(Number)
-  
-    if (aTime !== bTime) return aTime - bTime
-    return aSeq - bSeq
-  }
+  const [aTime = 0n, aSequence = 0n] = a.split("-").map(BigInt)
+  const [bTime = 0n, bSequence = 0n] = b.split("-").map(BigInt)
+
+  if (aTime < bTime) return -1
+  if (aTime > bTime) return 1
+  if (aSequence < bSequence) return -1
+  if (aSequence > bSequence) return 1
+  return 0
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,8 +15,15 @@ export const systemEvent = z.discriminatedUnion("type", [
 
 export type SystemEvent = z.infer<typeof systemEvent>
 
+export const STREAM_ID_PATTERN = /^\d+-\d+$/
+
+/** An opaque position returned by a server-side subscription. */
+export const realtimeCursor = z.string().regex(STREAM_ID_PATTERN).brand<"RealtimeCursor">()
+
+export type RealtimeCursor = z.infer<typeof realtimeCursor>
+
 export const userEvent = z.object({
-  id: z.string(),
+  id: realtimeCursor,
   data: z.unknown(),
   event: z.string(),
   channel: z.string(),

--- a/test/realtime.test.js
+++ b/test/realtime.test.js
@@ -1,29 +1,43 @@
 import { expect, test } from "bun:test"
 import { EventEmitter } from "node:events"
 
-import { Realtime } from "../src/server/index.js"
+import { CursorUnavailableError, Realtime } from "../src/server/index.js"
+import { compareStreamIds } from "../src/server/utils.js"
 
 class FakeSubscriber extends EventEmitter {
+  unsubscribeCalls = 0
+
   async unsubscribe() {
+    this.unsubscribeCalls += 1
     this.emit("unsubscribe", 0)
   }
 }
 
-function setup({ historyEvents }) {
+function withCursor(event) {
+  return { ...event, cursor: event.id }
+}
+
+function setup({ historyEvents, historyError, subscribeOptions = { history: true } }) {
   const subscriber = new FakeSubscriber()
   const snapshotCaptured = Promise.withResolvers()
   const releaseHistory = Promise.withResolvers()
-  const history = Object.fromEntries(
-    historyEvents.map(({ id, ...fields }) => [id, fields])
-  )
+  const rangeCalls = []
   const redis = {
     subscribe() {
       return subscriber
     },
-    async xrange() {
+    async xrange(...args) {
+      rangeCalls.push(args)
       snapshotCaptured.resolve()
       await releaseHistory.promise
-      return history
+      if (historyError) throw historyError
+
+      const [, start = "-"] = args
+      const selected =
+        start === "-"
+          ? historyEvents
+          : historyEvents.filter(({ id }) => compareStreamIds(id, start) >= 0)
+      return Object.fromEntries(selected.map(({ id, ...fields }) => [id, fields]))
     },
     async publish() {
       return 1
@@ -33,13 +47,20 @@ function setup({ historyEvents }) {
   const realtime = new Realtime({ redis })
   const subscribe = realtime.channel("updates").subscribe({
     events: ["update"],
-    history: true,
     onData(event) {
       received.push(event)
     },
+    ...subscribeOptions,
   })
 
-  return { subscriber, snapshotCaptured, releaseHistory, subscribe, received }
+  return {
+    subscriber,
+    snapshotCaptured,
+    releaseHistory,
+    subscribe,
+    received,
+    rangeCalls,
+  }
 }
 
 async function subscribeWithDelayedHistory({ historyEvents, liveEvent }) {
@@ -76,7 +97,7 @@ test("replays history before live events received during replay", async () => {
     liveEvent,
   })
 
-  expect(received).toEqual([historyEvent, liveEvent])
+  expect(received).toEqual([withCursor(historyEvent), withCursor(liveEvent)])
 })
 
 test("deduplicates live events already included in history", async () => {
@@ -91,7 +112,7 @@ test("deduplicates live events already included in history", async () => {
     liveEvent: event,
   })
 
-  expect(received).toEqual([event])
+  expect(received).toEqual([withCursor(event)])
 })
 
 test("deduplicates live events that arrive after replay completes", async () => {
@@ -121,7 +142,222 @@ test("deduplicates live events that arrive after replay completes", async () => 
   subscriber.emit("message", { channel: "updates", message: freshEvent })
   unsubscribe()
 
-  expect(received).toEqual([historyEvent, freshEvent])
+  expect(received).toEqual([withCursor(historyEvent), withCursor(freshEvent)])
+})
+
+test("resumes exclusively after a retained cursor", async () => {
+  const events = [
+    {
+      id: "1-0",
+      event: "update",
+      channel: "updates",
+      data: { value: "before" },
+    },
+    {
+      id: "2-0",
+      event: "update",
+      channel: "updates",
+      data: { value: "acknowledged" },
+    },
+    {
+      id: "3-0",
+      event: "update",
+      channel: "updates",
+      data: { value: "missed" },
+    },
+  ]
+  const { subscriber, releaseHistory, subscribe, received, rangeCalls } = setup({
+    historyEvents: events,
+    subscribeOptions: { after: "2-0" },
+  })
+
+  subscriber.emit("subscribe", 1)
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+  unsubscribe()
+
+  expect(rangeCalls).toEqual([["updates", "2-0", "+"]])
+  expect(received).toEqual([withCursor(events[2])])
+})
+
+test("accepts a cursor from an event outside the subscription filter", async () => {
+  const cursorEvent = {
+    id: "2-0",
+    event: "ignored",
+    channel: "updates",
+    data: { value: "acknowledged" },
+  }
+  const missedEvent = {
+    id: "3-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "missed" },
+  }
+  const { subscriber, releaseHistory, subscribe, received } = setup({
+    historyEvents: [cursorEvent, missedEvent],
+    subscribeOptions: { after: cursorEvent.id },
+  })
+
+  subscriber.emit("subscribe", 1)
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+  unsubscribe()
+
+  expect(received).toEqual([withCursor(missedEvent)])
+})
+
+test("adds a cursor to live events without history replay", async () => {
+  const liveEvent = {
+    id: "3-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "live" },
+  }
+  const { subscriber, subscribe, received, rangeCalls } = setup({
+    historyEvents: [],
+    subscribeOptions: {},
+  })
+
+  subscriber.emit("subscribe", 1)
+  const unsubscribe = await subscribe
+  subscriber.emit("message", { channel: "updates", message: liveEvent })
+  unsubscribe()
+
+  expect(rangeCalls).toEqual([])
+  expect(received).toEqual([withCursor(liveEvent)])
+})
+
+test("does not redeliver the cursor when no events were missed", async () => {
+  const acknowledged = {
+    id: "2-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "acknowledged" },
+  }
+  const fresh = {
+    id: "3-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "fresh" },
+  }
+  const { subscriber, releaseHistory, subscribe, received } = setup({
+    historyEvents: [acknowledged],
+    subscribeOptions: { after: acknowledged.id },
+  })
+
+  subscriber.emit("subscribe", 1)
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+  subscriber.emit("message", { channel: "updates", message: acknowledged })
+  subscriber.emit("message", { channel: "updates", message: fresh })
+  unsubscribe()
+
+  expect(received).toEqual([withCursor(fresh)])
+})
+
+test("rejects a cursor that is no longer retained", async () => {
+  const { subscriber, snapshotCaptured, releaseHistory, subscribe } = setup({
+    historyEvents: [
+      {
+        id: "3-0",
+        event: "update",
+        channel: "updates",
+        data: { value: "first retained" },
+      },
+    ],
+    subscribeOptions: { after: "2-0" },
+  })
+
+  subscriber.emit("subscribe", 1)
+  await snapshotCaptured.promise
+  releaseHistory.resolve()
+
+  const error = await subscribe.then(
+    () => new Error("Expected the subscription to reject"),
+    (cause) => cause
+  )
+  expect(error).toBeInstanceOf(CursorUnavailableError)
+  expect(error).toMatchObject({ channel: "updates", cursor: "2-0" })
+  expect(subscriber.unsubscribeCalls).toBe(1)
+})
+
+test("rejects after together with history", async () => {
+  const { subscribe } = setup({
+    historyEvents: [],
+    subscribeOptions: { after: "2-0", history: true },
+  })
+
+  await expect(subscribe).rejects.toBeInstanceOf(TypeError)
+})
+
+test("rejects and cleans up when history replay fails", async () => {
+  const historyError = new Error("History failed")
+  const { subscriber, snapshotCaptured, releaseHistory, subscribe } = setup({
+    historyEvents: [],
+    historyError,
+  })
+
+  subscriber.emit("subscribe", 1)
+  await snapshotCaptured.promise
+  releaseHistory.resolve()
+
+  await expect(subscribe).rejects.toBe(historyError)
+  expect(subscriber.unsubscribeCalls).toBe(1)
+})
+
+test("compares the full Redis stream sequence", async () => {
+  const historyEvent = {
+    id: "1-9007199254740992",
+    event: "update",
+    channel: "updates",
+    data: { value: "history" },
+  }
+  const liveEvent = {
+    id: "1-9007199254740993",
+    event: "update",
+    channel: "updates",
+    data: { value: "live" },
+  }
+
+  const received = await subscribeWithDelayedHistory({
+    historyEvents: [historyEvent],
+    liveEvent,
+  })
+
+  expect(received).toEqual([withCursor(historyEvent), withCursor(liveEvent)])
+})
+
+test("ignores live events with an invalid stream id", async () => {
+  const historyEvent = {
+    id: "1-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "history" },
+  }
+  const invalidEvent = {
+    id: "invalid",
+    event: "update",
+    channel: "updates",
+    data: { value: "invalid" },
+  }
+  const liveEvent = {
+    id: "2-0",
+    event: "update",
+    channel: "updates",
+    data: { value: "live" },
+  }
+  const { subscriber, releaseHistory, subscribe, received } = setup({
+    historyEvents: [historyEvent],
+  })
+
+  subscriber.emit("subscribe", 1)
+  releaseHistory.resolve()
+  const unsubscribe = await subscribe
+  subscriber.emit("message", { channel: "updates", message: invalidEvent })
+  subscriber.emit("message", { channel: "updates", message: liveEvent })
+  unsubscribe()
+
+  expect(received).toEqual([withCursor(historyEvent), withCursor(liveEvent)])
 })
 
 test("does not start the ping interval when unsubscribed during replay", async () => {


### PR DESCRIPTION
Closes #25

## Summary

Server-side subscriptions now support cursor-based resumption:

- Every delivered event carries an opaque `cursor` (`SubscriptionEvent` adds it to the delivered payload).
- `subscribe({ after })` resumes exclusively after the given cursor: missed events are replayed from the stream, then live delivery continues with handover deduplication, so reconnection work is proportional to the number of missed events rather than the total retained history.
- A trimmed, expired or malformed cursor rejects the initial subscription with `CursorUnavailableError`, distinguishing it from an ordinary empty replay.
- `after` and `history` are mutually exclusive, enforced both at the type level (a union with `never`) and at runtime for plain-JavaScript callers.
- A short usage guide is included at `docs/server-side-cursor-resumption.md`.

## Design notes

- **Opaque cursors are branded strings, minted by the schema.** `RealtimeCursor` is inferred from the shared `realtimeCursor` schema (`z.string().regex(STREAM_ID_PATTERN).brand<"RealtimeCursor">()`), which also types `userEvent.id` — validation and branding happen in one place, so no `as RealtimeCursor` casts exist anywhere. The sole trust boundary is `emit()`, where the id returned by XADD passes through `realtimeCursor.parse()` as a runtime assertion. A cursor persists as a plain string, and a stored string is narrowed back through the exported `isRealtimeCursor` type guard before it can be passed to `after` — the TypeScript analogue of an abstract type behind a module seal. `CursorUnavailableError.cursor` deliberately stays a plain `string`, since it may carry an invalid input for diagnostics.
- **Trim detection in a single round trip.** The replay fetches the range inclusively from `after` and checks that the first entry is the cursor itself; its absence means the cursor has been trimmed or has expired. An exclusive range (`(` syntax) could not distinguish "trimmed" from "no missed events".
- **Stream-id validation lives in the shared schema.** `userEvent.id` is validated against `STREAM_ID_PATTERN`, so every consumer (including the SSE handler's own dedup path) drops malformed foreign events uniformly instead of guarding a single call site.
- **`compareStreamIds` now uses BigInt**, so sequence numbers beyond 2^53 compare correctly; the behaviour is pinned by a regression test.
- **Failed replays reject and clean up.** An XRANGE failure (or an unavailable cursor) unsubscribes the underlying Redis subscription and rejects the `subscribe` promise instead of leaving it hanging.

## Deliberately out of scope

- **Paginating the `after` replay.** The catch-up XRANGE is a single unbounded fetch; paginating it would change the Redis call pattern and delivery timing, and Upstash's REST transport returns the whole response in one payload anyway. Worth revisiting if very old cursors over large retained streams become a real workload.
- **Unifying the replay/handover pipelines.** `realtime.ts` and `handler.ts` still carry parallel implementations of the replay → dedupe → handover flow; extracting a shared mechanism is a broader refactor best done separately. The schema-level id validation above already removes the sharpest edge (the handler's dedup path meeting a malformed id).
- **Returning the cursor from `emit()`.** Mentioned in the issue as a nice-to-have; cursor-aware subscription was the primary requirement.
- **Micro-optimisations**, such as an allocation-free comparator or attaching the cursor without an object spread — measured against the adjacent zod parse they are noise, and both would trade clarity for it.

## Testing

- `bun test` — 13 tests covering exclusive resumption, cursor delivery, handover deduplication, trimmed-cursor rejection, replay-failure cleanup and full-precision stream-id comparison.
- `tsc` — clean; brand semantics verified separately (a plain string or string literal no longer type-checks as `after`).